### PR TITLE
nginx - react router bug fixed

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -16,6 +16,10 @@ FROM nginx:stable
 
 COPY --from=build /webapp-ts-template-client/build /usr/share/nginx/html
 
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY nginx.conf /etc/nginx/conf.d
+
 EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    location / {
+      root   /usr/share/nginx/html;
+      index  index.html index.htm;
+      try_files $uri $uri/ /index.html;
+    } 
+    error_page 404 /index.html;
+    location = / {
+      root /usr/share/nginx/html;
+      internal;
+    }
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+      root   /usr/share/nginx/html;
+    }
+  }


### PR DESCRIPTION
The problem was that in docker production mode app went 404 if you refresh the page, or if you try to reach any of the app destinations except pure localhost.

I fixed it the way that I added nginx config file which is copied to the node during the build procedure.